### PR TITLE
rename the module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/shogo82148/fsnotify.svg)](https://pkg.go.dev/github.com/shogo82148/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/shogo82148/fsnotify)](https://goreportcard.com/report/github.com/shogo82148/fsnotify)
 
-## This project is archived.
+fsnotify utilizes [`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys) rather than [`syscall`](https://pkg.go.dev/syscall) from the standard library.
 
-[Details](https://github.com/fsnotify/fsnotify/issues/413) of this decision.
-
-## Cross platform
-
-`fsnotify` supports Windows, Linux, BSD and macOS with a common API.
+Cross platform: Windows, Linux, BSD and macOS.
 
 | Adapter               | OS                               | Status                                                                                                                          |
 | --------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
@@ -24,8 +20,6 @@
 \* Android and iOS are untested.
 
 Please see [the documentation](https://pkg.go.dev/github.com/shogo82148/fsnotify) and consult the [FAQ](#faq) for usage information.
-
-NOTE: fsnotify utilizes [`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys) rather than [`syscall`](https://pkg.go.dev/syscall) from the standard library.
 
 ## API stability
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # File system notifications for Go
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/fsnotify/fsnotify.svg)](https://pkg.go.dev/github.com/fsnotify/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/fsnotify/fsnotify)](https://goreportcard.com/report/github.com/fsnotify/fsnotify)
+[![Go Reference](https://pkg.go.dev/badge/github.com/shogo82148/fsnotify.svg)](https://pkg.go.dev/github.com/shogo82148/fsnotify) [![Go Report Card](https://goreportcard.com/badge/github.com/shogo82148/fsnotify)](https://goreportcard.com/report/github.com/shogo82148/fsnotify)
 
 ## This project is archived.
 
@@ -23,7 +23,7 @@
 
 \* Android and iOS are untested.
 
-Please see [the documentation](https://pkg.go.dev/github.com/fsnotify/fsnotify) and consult the [FAQ](#faq) for usage information.
+Please see [the documentation](https://pkg.go.dev/github.com/shogo82148/fsnotify) and consult the [FAQ](#faq) for usage information.
 
 NOTE: fsnotify utilizes [`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys) rather than [`syscall`](https://pkg.go.dev/syscall) from the standard library.
 
@@ -31,7 +31,7 @@ NOTE: fsnotify utilizes [`golang.org/x/sys`](https://pkg.go.dev/golang.org/x/sys
 
 fsnotify is a fork of [howeyc/fsnotify](https://github.com/howeyc/fsnotify) with a new API as of v1.0. The API is based on [this design document](http://goo.gl/MrYxyA).
 
-All [releases](https://github.com/fsnotify/fsnotify/releases) are tagged based on [Semantic Versioning](http://semver.org/).
+All [releases](https://github.com/shogo82148/fsnotify/releases) are tagged based on [Semantic Versioning](http://semver.org/).
 
 ## Usage
 
@@ -41,7 +41,7 @@ package main
 import (
 	"log"
 
-	"github.com/fsnotify/fsnotify"
+	"github.com/shogo82148/fsnotify"
 )
 
 func main() {
@@ -117,7 +117,7 @@ fsnotify requires support from underlying OS to work. The current NFS protocol d
 [#11]: https://github.com/fsnotify/fsnotify/issues/11
 [#7]: https://github.com/howeyc/fsnotify/issues/7
 
-[contributing]: https://github.com/fsnotify/fsnotify/blob/master/CONTRIBUTING.md
+[contributing]: https://github.com/shogo82148/fsnotify/blob/main/CONTRIBUTING.md
 
 ## Related Projects
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/fsnotify/fsnotify
+module github.com/shogo82148/fsnotify
 
 go 1.16
 


### PR DESCRIPTION
[fsnotify/fsnotify](https://github.com/fsnotify/fsnotify) is archived, so I fork it.
