### PR TITLE
Go 1.18 is released

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
           - macos-latest
           - windows-latest
         go:
-          - '1.18.0-beta1'
+          - '1.18'
           - '1.17'
           - '1.16'
     runs-on: ${{ matrix.os }}
@@ -20,7 +20,6 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          stable: 'false'
           go-version: ${{ matrix.go }}
 
       - name: checkout
@@ -50,7 +49,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.17'
+          go-version: '1.18'
 
       - name: checkout
         uses: actions/checkout@v3

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,9 @@ module github.com/shogo82148/fsnotify
 
 go 1.16
 
-require golang.org/x/sys v0.0.0-20220412211240-33da011f77ad
+require golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d
 
 retract (
-    v1.5.3 // Published an incorrect branch accidentally https://github.com/fsnotify/fsnotify/issues/445
-    v1.5.0 // Contains symlink regression https://github.com/fsnotify/fsnotify/pull/394
+	v1.5.3 // Published an incorrect branch accidentally https://github.com/fsnotify/fsnotify/issues/445
+	v1.5.0 // Contains symlink regression https://github.com/fsnotify/fsnotify/pull/394
 )

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad h1:ntjMns5wyP/fN65tdBD4g8J5w8n015+iIIs9rtjXkY0=
-golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d h1:/m5NbqQelATgoSPVC2Z23sR4kVNokFwDDyWh/3rGY+I=
+golang.org/x/sys v0.0.0-20220708085239-5a0f0661e09d/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
Go 1.18 is now officially available