### PR TITLE
add Go 1.22 to the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.17'
+          go-version: "1.22"
 
       - name: checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,15 +12,18 @@ jobs:
           - macos-latest
           - windows-latest
         go:
-          - '1.18.0-beta1'
-          - '1.17'
-          - '1.16'
+          - "1.22"
+          - "1.21"
+          - "1.20"
+          - "1.19"
+          - "1.18"
+          - "1.17"
+          - "1.16"
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go
         uses: actions/setup-go@v5
         with:
-          stable: 'false'
           go-version: ${{ matrix.go }}
 
       - name: checkout
@@ -50,7 +53,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.17'
+          go-version: "1.22"
 
       - name: checkout
         uses: actions/checkout@v4
@@ -68,4 +71,3 @@ jobs:
         continue-on-error: true
         with:
           version: latest
-          skip-go-installation: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,13 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - macos-13
+          - macos-12
+          - macos-11
+          - windows-2022
+          - windows-2019
         go:
           - "1.22"
           - "1.21"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,12 @@ jobs:
           - "1.19"
           - "1.18"
           - "1.17"
+        exclude:
+          # TODO: fix: exit status 0xc0000139
+          - os: windows-2019
+            go: "1.22"
+          - os: windows-2010
+            go: "1.21"
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           # TODO: fix: exit status 0xc0000139
           - os: windows-2019
             go: "1.22"
-          - os: windows-2010
+          - os: windows-2019
             go: "1.21"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
           - "1.19"
           - "1.18"
           - "1.17"
-          - "1.16"
     runs-on: ${{ matrix.os }}
     steps:
       - name: setup Go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shogo82148/fsnotify
 
-go 1.16
+go 1.17
 
 require golang.org/x/sys v0.18.0
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Updated Go version in build and test workflows to ensure compatibility with the latest Go versions and improve application performance and security.
	- Adjusted setup to use the latest Go version for the macOS job to maintain consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->