### PR TITLE
macos: retry if open() returns EINTR

### DIFF
--- a/kqueue.go
+++ b/kqueue.go
@@ -229,8 +229,17 @@ func (w *Watcher) addWatch(name string, flags uint32) (string, error) {
 			}
 		}
 
-		watchfd, err = unix.Open(name, openMode, 0700)
-		if watchfd == -1 {
+		// Retry on EINTR; open() can return EINTR in practice on macOS.
+		// See #354, and go issues 11180 and 39237.
+		for {
+			watchfd, err = unix.Open(name, openMode, 0)
+			if err == nil {
+				break
+			}
+			if errors.Is(err, unix.EINTR) {
+				continue
+			}
+
 			return "", err
 		}
 


### PR DESCRIPTION
port of https://github.com/fsnotify/fsnotify/pull/475

Retry the unix.Open() if the error returned is EINTR; looking around the web it seems many systems handle it like this. This is also what os.Open() does:
https://github.com/golang/go/commit/50d0ee0c98ea21f818d2daa9bc21ef51861a2ef9
