### PR TITLE
inotify: fix race in Close() (#465)

### DIFF
--- a/inotify.go
+++ b/inotify.go
@@ -69,12 +69,15 @@ func (w *Watcher) isClosed() bool {
 
 // Close removes all watches and closes the events channel.
 func (w *Watcher) Close() error {
+	w.mu.Lock()
 	if w.isClosed() {
+		w.mu.Unlock()
 		return nil
 	}
 
 	// Send 'close' signal to goroutine, and set the Watcher to closed.
 	close(w.done)
+	w.mu.Unlock()
 
 	// Causes any blocking reads to return with an error, provided the file still supports deadline operations
 	err := w.inotifyFile.Close()

--- a/inotify_test.go
+++ b/inotify_test.go
@@ -354,14 +354,16 @@ func TestInotifyInnerMapLength(t *testing.T) {
 	_ = <-w.Events                      // consume Remove event
 	<-time.After(50 * time.Millisecond) // wait IN_IGNORE propagated
 
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if len(w.watches) != 0 {
-		t.Fatalf("Expected watches len is 0, but got: %d, %v", len(w.watches), w.watches)
-	}
-	if len(w.paths) != 0 {
-		t.Fatalf("Expected paths len is 0, but got: %d, %v", len(w.paths), w.paths)
-	}
+	func() {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if len(w.watches) != 0 {
+			t.Fatalf("Expected watches len is 0, but got: %d, %v", len(w.watches), w.watches)
+		}
+		if len(w.paths) != 0 {
+			t.Fatalf("Expected paths len is 0, but got: %d, %v", len(w.paths), w.paths)
+		}
+	}()
 
 	w.Close()
 	wg.Wait()

--- a/integration_test.go
+++ b/integration_test.go
@@ -1248,6 +1248,21 @@ func TestRemoveWithClose(t *testing.T) {
 	}
 }
 
+// Make sure Close() doesn't race; hard to write a good reproducible test for
+// this, but running it 150 times seems to reproduce it in ~75% of cases and
+// isn't too slow (~0.06s on my system).
+func TestCloseRace(t *testing.T) {
+	for i := 0; i < 150; i++ {
+		w, err := NewWatcher()
+		if err != nil {
+			t.Fatal(err)
+		}
+		go w.Close()
+		go w.Close()
+		go w.Close()
+	}
+}
+
 func testRename(file1, file2 string) error {
 	switch runtime.GOOS {
 	case "windows", "plan9":

--- a/windows.go
+++ b/windows.go
@@ -51,10 +51,13 @@ func NewWatcher() (*Watcher, error) {
 
 // Close removes all watches and closes the events channel.
 func (w *Watcher) Close() error {
+	w.mu.Lock()
 	if w.isClosed {
+		w.mu.Unlock()
 		return nil
 	}
 	w.isClosed = true
+	w.mu.Unlock()
 
 	// Send "quit" message to the reader goroutine
 	ch := make(chan error)
@@ -68,6 +71,7 @@ func (w *Watcher) Close() error {
 // Add starts watching the named file or directory (non-recursively).
 func (w *Watcher) Add(name string) error {
 	if w.isClosed {
+		w.mu.Unlock()
 		return errors.New("watcher already closed")
 	}
 	in := &input{

--- a/windows.go
+++ b/windows.go
@@ -70,10 +70,12 @@ func (w *Watcher) Close() error {
 
 // Add starts watching the named file or directory (non-recursively).
 func (w *Watcher) Add(name string) error {
+	w.mu.Lock()
 	if w.isClosed {
 		w.mu.Unlock()
 		return errors.New("watcher already closed")
 	}
+	w.mu.Unlock()
 	in := &input{
 		op:    opAddWatch,
 		path:  filepath.Clean(name),


### PR DESCRIPTION
Would sometimes fail with:

	panic: close of closed channel

	goroutine 204 [running]:
	github.com/fsnotify/fsnotify.(*Watcher).Close(0xc0003e6410)
        	/home/martin/code/Golib/fsnotify/inotify.go:82 +0x66
	created by github.com/fsnotify/fsnotify.TestCloseRace
        	/home/martin/code/Golib/fsnotify/integration_test.go:1256 +0x1a5
	exit status 2

Because isClosed() might return "false" for two goroutines, and then they will both try to close it, resulting in the panic.
